### PR TITLE
Workaround for negative account balances

### DIFF
--- a/src/commands/account/general.rs
+++ b/src/commands/account/general.rs
@@ -58,6 +58,10 @@ pub async fn payday(ctx: &Context, msg: &Message, _args: Args) -> CommandResult 
         if hours_diff > 23 {
             let updated_amount = bank.amount + 1000;
 
+            if updated_amount <= 0 {
+                let updated_amount = 1000;
+            }
+
             Bank::update(
                 &mut *get_client(&ctx).await?,
                 *msg.author.id.as_u64() as i64,

--- a/src/commands/account/general.rs
+++ b/src/commands/account/general.rs
@@ -57,7 +57,7 @@ pub async fn payday(ctx: &Context, msg: &Message, _args: Args) -> CommandResult 
             .num_hours();
         if hours_diff > 23 {
             let updated_amount = bank.amount + 1000;
-
+            // Fix negative account balance
             if updated_amount <= 0 {
                 let updated_amount = 1000;
             }


### PR DESCRIPTION
Resets the user's account balance with payday command, when the balance is negative.