### PR TITLE
Fixed faulty command description

### DIFF
--- a/src/commands/selfmute.rs
+++ b/src/commands/selfmute.rs
@@ -17,7 +17,7 @@ use tracing::error;
 
 #[command]
 #[num_args(1)]
-#[description = "Mutes youself for the given duration supports (w, d, h, m, s)"]
+#[description = "Mutes youself for the given duration supports (d, h, m, s)"]
 #[usage = "*duration*"]
 #[example = "1h"]
 #[only_in("guilds")]


### PR DESCRIPTION
Selfmute for more than 24 hours is not possible, command description was faulty. Removed 'w' (=weeks) from list of available selfmute durations.